### PR TITLE
Update voyager_tinymce.js with setup callback

### DIFF
--- a/resources/assets/js/voyager_tinymce.js
+++ b/resources/assets/js/voyager_tinymce.js
@@ -27,6 +27,11 @@ $(document).ready(function(){
         if (typeof tinymce_init_callback !== "undefined") {
             tinymce_init_callback(editor);
         }
+    },
+    setup: function (editor) {
+        if (typeof tinymce_setup_callback !== "undefined") {
+            tinymce_setup_callback(editor);
+        }
     }
   });
 


### PR DESCRIPTION
This callback allows developers to access the TinyMCE Editor BEFORE it has been instantiated. Useful for adding plugins etc...

One could simply destroy and create a new instance in the init callback but that felt like a workaround

`var tinymce_setup_callback = function(editor){

        editor.settings.plugins = 'link, image, code, youtube, giphy, table, textcolor, lists, media';
        editor.settings.media_dimensions = false;
        editor.video_template_callback = function(data) {
            //..
        };
};`
